### PR TITLE
Add CI smoke-test, smoke-test script, issue proposals, and harden latte-gacha JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run smoke test
+        run: ./scripts/smoke-test.sh

--- a/ISSUE_PROPOSALS.md
+++ b/ISSUE_PROPOSALS.md
@@ -1,0 +1,96 @@
+# 작업 제안서 (코드베이스 점검 결과)
+
+아래는 현재 코드베이스를 빠르게 점검한 뒤 정리한 **우선순위 작업 4건**입니다.
+
+## 1) 오탈자 수정 작업
+### 제안
+- 카테고리/경로 명칭 `lattecolection`(l 1개) → `lattecollection`(l 2개)로 통일.
+
+### 근거
+- 카테고리 파일명과 포스트 경로에서 동일 오탈자가 반복됨.
+  - `_category/lattecolection.md`
+  - `_posts/lattecolection/2026-04-01-caffe-latte.md`
+
+### 기대 효과
+- URL/카테고리 네이밍 일관성 개선
+- 검색/내부 링크 관리 시 혼동 감소
+
+---
+
+## 2) 버그 수정 작업
+### 제안
+- `assets/js/latte-gacha.js`에 DOM 존재 여부 가드 추가.
+- `.gacha__action_btn`, `.gacha__result`, `.gacha__desc`가 없는 페이지에서는 조용히 종료하도록 개선.
+
+### 예시
+```js
+const gachaBtn = document.querySelector(".gacha__action_btn");
+const gachaResult = document.querySelector(".gacha__result");
+const gachaDesc = document.querySelector(".gacha__desc");
+
+if (!gachaBtn || !gachaResult || !gachaDesc) {
+  // 가챠 UI가 없는 페이지에서는 아무 것도 하지 않음
+  return;
+}
+```
+- 적용 포인트: 이벤트 바인딩(`addEventListener`) 전에 위 가드를 넣어 페이지별 스크립트 에러를 차단.
+
+### 근거
+- 현재 스크립트는 요소가 없을 때도 `gachaBtn.addEventListener(...)`를 호출하므로, 특정 페이지에서 런타임 에러 가능성이 있음.
+
+### 기대 효과
+- 가챠 위젯이 없는 페이지에서도 전역 JS 안전성 확보
+- 콘솔 에러 감소 및 회귀 위험 축소
+
+---
+
+## 3) 코드 주석/문서 불일치 수정 작업
+### 제안
+- README에 실제 기능 범위(예: Latte Gacha 페이지 존재, 주요 정보 페이지 링크)를 2~3줄로 명시.
+- 또는 `_info/lattegacha.md` 상단에 기능 설명/주의사항을 문서형으로 추가해 include 마크업만 있는 상태를 보완.
+
+### 근거
+- `README.md`는 현재 매우 간략하여 실제 제공 기능(라떼 가챠 등)과 사용자가 기대하는 문서 정보가 어긋남.
+- `_info/lattegacha.md`는 include 호출 중심이라 기능 의도/동작 제약이 드러나지 않음.
+
+### 기대 효과
+- 신규 기여자 온보딩 속도 향상
+- 문서-구현 간 인지 부조화 감소
+
+---
+
+## 4) 테스트 개선 작업
+### 제안
+- 최소 smoke test 도입:
+  1. Jekyll 빌드 성공 여부(`bundle exec jekyll build`)
+  2. 핵심 페이지 렌더링 확인(`index.html`, `lattegacha` 페이지)
+  3. 가챠 JS 기본 동작(요소 없음/데이터 없음) 검증
+- GitHub Actions에 CI 워크플로우 추가하여 PR마다 자동 실행.
+
+### 예시
+- 로컬/CI에서 공통으로 실행할 스모크 테스트 예시:
+```bash
+bundle exec jekyll build
+test -f _site/index.html
+test -f _site/info/lattegacha/index.html
+```
+- JS 회귀 방지용 테스트(예: Vitest + jsdom) 시나리오 예시:
+  - **케이스 A**: 가챠 DOM이 전혀 없는 문서에서 스크립트를 로드해도 예외가 발생하지 않아야 함.
+  - **케이스 B**: `#latte-data`가 비어 있거나 `[]`일 때 버튼 클릭 시 “준비 중 ...” 문구가 노출되어야 함.
+- GitHub Actions 워크플로우 예시:
+  - PR 트리거 시 `bundle install` → `bundle exec jekyll build` → 스모크 테스트 스크립트 실행.
+
+### 근거
+- 저장소에 테스트/CI 설정이 거의 없어, 사소한 수정에도 정적 사이트/스크립트 회귀를 즉시 감지하기 어려움.
+
+### 기대 효과
+- 배포 전 품질 게이트 확보
+- 프론트 JS 회귀 조기 탐지
+
+---
+
+## 권장 우선순위
+1. 버그 수정(2)
+2. 테스트 개선(4)
+3. 오탈자 수정(1)
+4. 문서 불일치 수정(3)

--- a/assets/js/latte-gacha.js
+++ b/assets/js/latte-gacha.js
@@ -1,76 +1,87 @@
 // use Math.random for simple gacha randomness (not cryptographically secure)
 // load latte data from json script
 const raw = document.getElementById("latte-data")?.textContent || "[]";
-const lattes = JSON.parse(raw);
+
+let lattes = [];
+try {
+  lattes = JSON.parse(raw);
+} catch (err) {
+  lattes = [];
+}
 
 // cache dom elements for gacha ui
 const gachaBtn = document.querySelector(".gacha__action_btn");
 const gachaResult = document.querySelector(".gacha__result");
 const gachaDesc = document.querySelector(".gacha__desc");
 
-// manage spin state and final result
-let gachaDelay = 40;
-let gachaCount = 0;
-let finalPick = null;
+// guard: skip script on pages without gacha UI
+if (!gachaBtn || !gachaResult || !gachaDesc) {
+  // no-op: this script can be loaded globally
+} else {
+  // manage spin state and final result
+  let gachaDelay = 40;
+  let gachaCount = 0;
+  let finalPick = null;
 
-// run spin animation with increasing delay
-function gachaSpin() {
-  setTimeout(() => {
-    // pick random latte for spin display
-    const spinIndex = Math.floor(Math.random() * lattes.length);
-    const spinPick = lattes[spinIndex];
+  // run spin animation with increasing delay
+  function gachaSpin() {
+    setTimeout(() => {
+      // pick random latte for spin display
+      const spinIndex = Math.floor(Math.random() * lattes.length);
+      const spinPick = lattes[spinIndex];
 
-    gachaResult.classList.add("spinning");
-    gachaResult.textContent = spinPick.name + " ...";
-    gachaDesc.classList.add("spinning");
-    gachaDesc.textContent = "고민 중 ...";
+      gachaResult.classList.add("spinning");
+      gachaResult.textContent = spinPick.name + " ...";
+      gachaDesc.classList.add("spinning");
+      gachaDesc.textContent = "고민 중 ...";
 
-    // slow down spin over time
-    gachaDelay += 10;
+      // slow down spin over time
+      gachaDelay += 10;
 
-    // track spin iterations
-    gachaCount += 1;
+      // track spin iterations
+      gachaCount += 1;
 
-    // continue or finish spin
-    if (gachaCount < 20) {
-      gachaSpin();
-    } else {
-      // initialize after completion
-      gachaResult.classList.remove("spinning");
-      gachaResult.textContent = finalPick.name;
-      gachaDesc.classList.remove("spinning");
-      gachaDesc.textContent = finalPick.description;
-      gachaBtn.textContent = "한번 더 뽑기";
-      gachaBtn.disabled = false;
-      gachaDelay = 40;
-      gachaCount = 0;
-    }
-  }, gachaDelay);
-}
-
-// handle click to start gacha flow
-gachaBtn.addEventListener("click", () => {
-  // prevent execution if data is invalid or empty
-  if (!Array.isArray(lattes) || lattes.length === 0) {
-    gachaResult.textContent = "준비 중 ...";
-    gachaDesc.textContent = "아직 라떼가 준비되지 않았습니다 ...";
-    return;
+      // continue or finish spin
+      if (gachaCount < 20) {
+        gachaSpin();
+      } else {
+        // initialize after completion
+        gachaResult.classList.remove("spinning");
+        gachaResult.textContent = finalPick.name;
+        gachaDesc.classList.remove("spinning");
+        gachaDesc.textContent = finalPick.description;
+        gachaBtn.textContent = "한번 더 뽑기";
+        gachaBtn.disabled = false;
+        gachaDelay = 40;
+        gachaCount = 0;
+      }
+    }, gachaDelay);
   }
 
-  // disable button to avoid multiple triggers
-  gachaBtn.disabled = true;
+  // handle click to start gacha flow
+  gachaBtn.addEventListener("click", () => {
+    // prevent execution if data is invalid or empty
+    if (!Array.isArray(lattes) || lattes.length === 0) {
+      gachaResult.textContent = "준비 중 ...";
+      gachaDesc.textContent = "아직 라떼가 준비되지 않았습니다 ...";
+      return;
+    }
 
-  // reset spin state before starting
-  gachaDelay = 40;
-  gachaCount = 0;
+    // disable button to avoid multiple triggers
+    gachaBtn.disabled = true;
 
-  // update button text during spin
-  gachaBtn.textContent = "라떼 내리는 중...";
+    // reset spin state before starting
+    gachaDelay = 40;
+    gachaCount = 0;
 
-  // preselect final result before animation
-  const finalIndex = Math.floor(Math.random() * lattes.length);
-  finalPick = lattes[finalIndex];
+    // update button text during spin
+    gachaBtn.textContent = "라떼 내리는 중...";
 
-  // start spin animation
-  gachaSpin();
-});
+    // preselect final result before animation
+    const finalIndex = Math.floor(Math.random() * lattes.length);
+    finalPick = lattes[finalIndex];
+
+    // start spin animation
+    gachaSpin();
+  });
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle exec jekyll build
+
+# core pages must be rendered
+[[ -f "_site/index.html" ]]
+[[ -f "_site/info/lattegacha/index.html" ]]
+
+# gacha script should be present on lattegacha page
+grep -q 'assets/js/latte-gacha.js' _site/info/lattegacha/index.html
+
+echo "Smoke test passed"


### PR DESCRIPTION
### Motivation
- Add a minimal CI gate to detect Jekyll build or static-site regressions early by running a smoke test on PRs and pushes.
- Prevent runtime errors from the globally-loaded latte gacha script on pages that do not include the gacha UI.
- Capture and communicate immediate repo maintenance tasks and priorities in a single `ISSUE_PROPOSALS.md` file.

### Description
- Add a GitHub Actions workflow at `.github/workflows/ci.yml` that runs `./scripts/smoke-test.sh` on pull requests and pushes to `main`.
- Add `scripts/smoke-test.sh` which runs `bundle exec jekyll build` and asserts core outputs with checks for `_site/index.html`, `_site/info/lattegacha/index.html`, and presence of `assets/js/latte-gacha.js` in the rendered page.
- Harden `assets/js/latte-gacha.js` by adding robust JSON parsing for `#latte-data`, and a DOM guard so the script is a no-op on pages missing `.gacha__action_btn`, `.gacha__result`, or `.gacha__desc` to avoid `addEventListener` errors.
- Add `ISSUE_PROPOSALS.md` containing prioritized fixes (typo corrections, bug fixes, docs alignment, and testing improvements) and example snippets for follow-up work.

### Testing
- Executed the smoke checks locally by running `./scripts/smoke-test.sh` which runs `bundle exec jekyll build` and the site-file checks, and the script completed successfully.
- The CI workflow was added to run the same `./scripts/smoke-test.sh` on PRs and pushes, so the smoke test will run automatically on incoming changes.
- No unit tests were modified; only the smoke/regression checks above were introduced and validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed68a0f93c8321bb496aa21ed7ba27)